### PR TITLE
Updated recipe to PySDL 0.9.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PySDL2" %}
-{% set version = "0.9.4" %}
-{% set md5 = "720b33ed048c169643406ae39ca4dd8d" %}
+{% set version = "0.9.6" %}
+{% set md5 = "0ff0489089b5941fe77f7cdd5ff912bd" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The impetus for the update is that the recipe's PySDL2 0.9.4 does not support Python 3.6.